### PR TITLE
PR: Add support for L298N driver

### DIFF
--- a/3-Software/Arduino/.clang-format
+++ b/3-Software/Arduino/.clang-format
@@ -181,7 +181,7 @@ PenaltyReturnTypeOnItsOwnLine: 200
 # Note: see DerivePointerAlignment too, as it takes precedence
 PointerAlignment: Left
 RawStringFormats: 
-  - Delimiter:       pb
+  - Delimiters:       [pb]
     Language:        TextProto
     BasedOnStyle:    google
 ReflowComments:  true

--- a/3-Software/Arduino/ventilation_machine/ventilation_machine.ino
+++ b/3-Software/Arduino/ventilation_machine/ventilation_machine.ino
@@ -125,7 +125,7 @@ Use the Rate potentiometer to move the arm up/down.
 #    define curr_sense false         // o no current sensor
 #    define control_with_pot true    // 1 = control with potentiometers  0 = with push buttons
 #    define FF 7                     // motion control feed forward
-#    define KP 2                   // motion control propportional gain
+#    define KP 2                     // motion control propportional gain
 #    define KI 1                     // motion control integral gain
 #    define integral_limit 5         // limits the integral of error
 #    define f_reduction_up_val 0.85  // reduce feedforward by this factor when moving up
@@ -160,13 +160,11 @@ Use the Rate potentiometer to move the arm up/down.
 #define pin_FRQ 3  // analog pin of rate potentiometer control
 #define pin_PRE 6  // analog pin of pressure potentiometer control
 
-//L298N specific
+// L298N specific
 #define L298N false
-#define pin_SPEED   7   // analog
-#define pin_FORWARD 5   // digital
-#define pin_BACK    3   // digital
-
-
+#define pin_SPEED 7    // analog
+#define pin_FORWARD 5  // digital
+#define pin_BACK 3     // digital
 
 // Talon SR or SPARK controller PWM settings ("angle" for Servo library
 #define PWM_mid 93  // was 93 -   mid value for PWM 0 motion - higher pushes up
@@ -364,12 +362,13 @@ enum main_states state;
 /// @return     None
 void setup()
 {
-    if(L298N) {
-      pinMode(pin_SPEED, OUTPUT);
-      pinMode(pin_FORWARD, OUTPUT);  
-      pinMode(pin_BACK, OUTPUT);
+    if (L298N)
+    {
+        pinMode(pin_SPEED, OUTPUT);
+        pinMode(pin_FORWARD, OUTPUT);
+        pinMode(pin_BACK, OUTPUT);
     }
-    
+
     pinMode(pin_PWM, OUTPUT);
     pinMode(pin_FD, INPUT_PULLUP);
     pinMode(pin_FU, INPUT_PULLUP);
@@ -381,8 +380,9 @@ void setup()
     pinMode(pin_LED_FREQ, OUTPUT);
     pinMode(pin_LED_Fail, OUTPUT);
     pinMode(pin_USR, OUTPUT);
-    if (!L298N) {    
-       motor.attach(pin_PWM);
+    if (!L298N)
+    {
+        motor.attach(pin_PWM);
     }
     Serial.begin(115200);
     Serial.print("\nAmboVent Version: ");
@@ -1064,23 +1064,28 @@ void set_motor_PWM(float wanted_vel_PWM)
         wanted_vel_PWM = PWM_min;  // limit PWM
     motorPWM = PWM_mid + int(wanted_vel_PWM);
 
-    if (L298N){
-      if(motorPWM > PWM_mid + 3){  // leave a -3 to +3 stop range
-        digitalWrite(pin_FORWARD, HIGH);
-        digitalWrite(pin_BACK, LOW);
-      }
-      else if(motorPWM < PWM_mid - 3){  // leave a -3 to +3 stop range
-        digitalWrite(pin_FORWARD, LOW);
-        digitalWrite(pin_BACK, HIGH);
-      }
-      else {
-        digitalWrite(pin_FORWARD, LOW);
-        digitalWrite(pin_BACK, LOW);        
-      }
-    
-      analogWrite(pin_SPEED, map(motorPWM, PWM_min, PWM_max, 0, 25));
+    if (L298N)
+    {
+        if (motorPWM > PWM_mid + 3)
+        {  // leave a -3 to +3 stop range
+            digitalWrite(pin_FORWARD, HIGH);
+            digitalWrite(pin_BACK, LOW);
+        }
+        else if (motorPWM < PWM_mid - 3)
+        {  // leave a -3 to +3 stop range
+            digitalWrite(pin_FORWARD, LOW);
+            digitalWrite(pin_BACK, HIGH);
+        }
+        else
+        {
+            digitalWrite(pin_FORWARD, LOW);
+            digitalWrite(pin_BACK, LOW);
+        }
+
+        analogWrite(pin_SPEED, map(motorPWM, PWM_min, PWM_max, 0, 25));
     }
-    else {
+    else
+    {
         motor.write(motorPWM);
     }
 }


### PR DESCRIPTION
## Description:
Add support for L298N driver boards


## Checklist:
- [X] I have run the code formatter with `./run_clang-format.sh` (see main 
[README.md](https://github.com/AmboVent-1690-108/AmboVent#software) for details on how)
- [X] I have built the code in the Arduino IDE (or with the command-line tool) and pasted the 
build output below
- [X] If I have touched *any* lines of code in the software, other than comments, I have incremented
the version number string at the top of "ventilation_machine.ino" and updated the Software Changelog
in the main AmboVent readme.

**Arduino IDE build output:**  

Date and time I performed this build: YYYYMMDD-HHMMhrs  
(git hash ???????) (IDE ?.?.??) (Arduino __ ? __)

Sketch uses 18140 bytes (59%) of program storage space. Maximum is 30720 bytes.
Global variables use 1076 bytes (52%) of dynamic memory, leaving 972 bytes for local variables. Maximum is 2048 bytes.

<!-- Example:

20200420-0049hrs (git hash 493985f; branch fix_formatting) (IDE 1.8.12) (Arduino Nano) - PR #46: https://github.com/AmboVent-1690-108/AmboVent/pull/46

    Sketch uses 18176 bytes (56%) of program storage space. Maximum is 32256 bytes.
    Global variables use 1046 bytes (51%) of dynamic memory, leaving 1002 bytes for local variables. Maximum is 2048 bytes.

-->

